### PR TITLE
`image-publish.yml`: Support supplying build secret(s) [minor]

### DIFF
--- a/.github/workflows/image-publish.md
+++ b/.github/workflows/image-publish.md
@@ -62,11 +62,20 @@ Depending on the `mode`, secret(s) may be required:
 
 #### If interacting with CVMFS
 
-| Name                 | Required          | Description                                                                                                                                  |
-|----------------------|-------------------|----------------------------------------------------------------------------------------------------------------------------------------------|
-| `cvmfs_github_token` | ✅, if using CVMFS | GitHub PAT used to interact with  [`WIPACrepo/build-singularity-cvmfs-action`](https://github.com/WIPACrepo/build-singularity-cvmfs-action/) |
+| Name                 | Required          | Description                                                                                                                                 |
+|----------------------|-------------------|---------------------------------------------------------------------------------------------------------------------------------------------|
+| `cvmfs_github_token` | ✅, if using CVMFS | GitHub PAT used to interact with [`WIPACrepo/build-singularity-cvmfs-action`](https://github.com/WIPACrepo/build-singularity-cvmfs-action/) |
 
-## Tag Suffix and “latest” Behavior
+#### If building with Dockerfile secrets (`--mount=type=secret`)
+
+| Name                        | Required                                       | Description                                                                                             |
+|-----------------------------|------------------------------------------------|---------------------------------------------------------------------------------------------------------|
+| `dockerfile_secret_name_0`  | ⚠️, only if `dockerfile_secret_value_0` is set | The secret ID matching the Dockerfile's `--mount=type=secret,id=<name>` for secret 0.                   |
+| `dockerfile_secret_value_0` | ⚠️, only if `dockerfile_secret_name_0` is set  | The secret value for `dockerfile_secret_name_0`. Passed securely to BuildKit via `--mount=type=secret`. |
+
+> NOTE: Both are declared as `secrets:` (not `inputs:`) so their values are never exposed in the GitHub UI or workflow run logs. Additional pairs (`_1`, `_2`, ...) can be added in future versions.
+
+## Tag Suffix and "latest" Behavior
 
 When `tag_suffix` is provided (e.g., `tag_suffix: appt`):
 

--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -108,6 +108,19 @@ on:
             A PAT so the workflow can git push to GitHub (used for CVMFS build/removal requests)
           SEE: https://github.com/WIPACrepo/build-singularity-cvmfs-action
         required: false
+      dockerfile_secret_name_0:
+        description: |
+          IF BUILDING IMAGE with a secret (else, var is ignored):
+            The secret ID used in the Dockerfile's --mount=type=secret,id=<name>.
+          NOTE: This is included as a secret in the workflow, in case the user 
+            accidentally sets this to an actual secret token.
+        required: false
+      dockerfile_secret_value_0:
+        description: |
+          IF BUILDING IMAGE with a secret (else, var is ignored):
+            The secret value corresponding to 'dockerfile_secret_name_0'.
+        required: false
+
 
 jobs:
   validate-and-plan:
@@ -408,6 +421,30 @@ jobs:
           ########################################################################
           echo "🎯 All conditional input validations passed successfully."
 
+      - name: "Validate dockerfile secret pairs"
+        env:
+          SECRET_NAME_0: ${{ secrets.dockerfile_secret_name_0 }}
+          SECRET_VALUE_0: ${{ secrets.dockerfile_secret_value_0 }}
+          # SECRET_NAME_1: ${{ secrets.dockerfile_secret_name_1 }}
+          # SECRET_VALUE_1: ${{ secrets.dockerfile_secret_value_1 }}
+        run: |
+          set -euo pipefail
+          LAST_PAIR=0  # <- Update this if you add more secrets!
+          for i in $(seq 0 $LAST_PAIR); do
+            name_var="SECRET_NAME_${i}"
+            value_var="SECRET_VALUE_${i}"
+            name="${!name_var}"
+            value="${!value_var}"
+            if [[ -n "${name}" && -z "${value}" ]]; then
+              echo "::error::dockerfile_secret_name_${i} is set but dockerfile_secret_value_${i} is missing."
+              exit 1
+            fi
+            if [[ -z "${name}" && -n "${value}" ]]; then
+              echo "::error::dockerfile_secret_value_${i} is set but dockerfile_secret_name_${i} is missing."
+              exit 1
+            fi
+          done
+
       - name: "Normalize suffix for use in artifacts"
         id: suffix_norm_for_artifacts
         shell: bash
@@ -640,6 +677,7 @@ jobs:
           tags: ${{ inputs.image_registry }}/${{ inputs.image_namespace }}/${{ inputs.image_name }}
           labels: ${{ steps.docker_meta.outputs.labels }}
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
+          secrets: ${{ secrets.dockerfile_secret_name_0 != '' && format('{0}={1}', secrets.dockerfile_secret_name_0, secrets.dockerfile_secret_value_0) || '' }}
 
       # USE ARTIFACTS
       - name: "Store platform-specific image@digest in a file named for the platform"


### PR DESCRIPTION
Tested by https://github.com/icecube/skymap_scanner/compare/main...refs/heads/etinting/monopod_wilks. This uses a GitHub token to pip install a private package at build.